### PR TITLE
fix pandas mixed types in object-type columns

### DIFF
--- a/python/starfile_rs/components.py
+++ b/python/starfile_rs/components.py
@@ -321,6 +321,7 @@ class LoopDataBlock(DataBlock):
             new_columns: "list[pd.Series]" = []
             for column_name in df.columns:
                 if (col := df[column_name]).dtype.kind not in "biuf":
+                    col = col.astype(str)
                     cond = col.str.contains(" ") | (col == "")
                     new_col = col.where(~cond, '"' + col + '"')
                     new_columns.append(new_col)

--- a/python/tests/test_writing.py
+++ b/python/tests/test_writing.py
@@ -162,6 +162,17 @@ def test_empty_string_loop():
         'loop_\n_a #1\n_b #2\n""\t""\nnon-empty\t""'
     )
 
+def test_pandas_mixed_types():
+    # pandas prefer object type, which causes issues when writing STAR files
+    star = empty_star()
+    star["pandas"] = pd.DataFrame({"a": [1, "a b", 3.0], "b": [0, 1, 2]})
+    s0 = star.to_string(comment=None)
+    assert s0.strip() == (
+        'data_pandas\n\n'
+        'loop_\n_a #1\n_b #2\n'
+        '1\t0\n"a b"\t1\n3.0\t2'
+    )
+
 def test_string_with_space_simple():
     # strings with spaces should always be quoted
     star = empty_star()


### PR DESCRIPTION
Quoting fails when an object column contains string and numerical values. This PR fixes it.