### PR TITLE
fix `get_dataframe` call

### DIFF
--- a/python/starfile_rs/schema/pandas.py
+++ b/python/starfile_rs/schema/pandas.py
@@ -58,7 +58,7 @@ class LoopDataModel(LoopDataModelBase[pd.DataFrame]):
                         f"'{block.name}'."
                     )
                 else:
-                    dtype.pop(f.column_name)
+                    dtype.pop(f.column_name, None)
 
         names: list[str] = []
         usecols: list[int] = []

--- a/python/starfile_rs/schema/polars.py
+++ b/python/starfile_rs/schema/polars.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Generic, SupportsIndex, TypeVar, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Generic,
+    Iterator,
+    SupportsIndex,
+    TypeVar,
+    overload,
+)
 import polars as pl
 
 from starfile_rs.components import LoopDataBlock
@@ -23,6 +31,7 @@ if TYPE_CHECKING:
         def __getitem__(self, key: SupportsIndex) -> _T: ...
         @overload
         def __getitem__(self, key: slice) -> pl.Series[_T]: ...
+        def __iter__(self) -> Iterator[_T]: ...
 
 
 class Series(SeriesBase[_T]):
@@ -47,7 +56,7 @@ class LoopDataModel(LoopDataModelBase[pl.DataFrame]):
                         f"'{block.name}'."
                     )
                 else:
-                    schema.pop(f.column_name)
+                    schema.pop(f.column_name, None)
 
         field_names: set[str] = set()
         for f in fields:

--- a/python/tests/test_schema.py
+++ b/python/tests/test_schema.py
@@ -491,9 +491,20 @@ def test_write_with_empty_fields(tmpdir):
     assert m2.loop.dataframe.shape == (3, 1)
     assert "rlnCoordinateY" not in m2.loop.dataframe.columns
 
-def test_update_and_write(tmpdir):
+@pytest.mark.parametrize(
+    "loopDataModel, series",
+    [
+        (spd.LoopDataModel, spd.Series),
+        (spl.LoopDataModel, spl.Series),
+    ]
+)
+def test_update_and_write(tmpdir, loopDataModel, series):
     """Testing updating fields and writing back to file will update the content"""
-    from starfile_rs.schema.pandas import LoopDataModel, Series
+    if TYPE_CHECKING:
+        from starfile_rs.schema.pandas import LoopDataModel, Series
+    else:
+        LoopDataModel = loopDataModel
+        Series = series
 
     class OneLoop(LoopDataModel):
         x: Series[float] = Field("rlnCoordinateX")
@@ -532,3 +543,5 @@ def test_update_and_write(tmpdir):
     m3 = MyModel.validate_file(save_path)
     assert m3.general.final_res == pytest.approx(20.0)
     assert m3.general.rlnMaskName == "mask8.mrc"
+
+    assert m.loop.dataframe.columns == ["rlnCoordinateX"]


### PR DESCRIPTION
polars schema with optional value fails to read dataframe due to missing columns. This PR fixes it.